### PR TITLE
Use consistent color for red

### DIFF
--- a/static/assets/stylesheets/style.scss
+++ b/static/assets/stylesheets/style.scss
@@ -192,7 +192,7 @@ img.footer-logo{
 .district-label{
   margin-top: -30px;
   span{
-    background: red;
+    background: #ff5252;
     padding: 5px;
     font-size: 21px;
 


### PR DESCRIPTION
Used consistent red color for background of district name that is already used in background under it.

Previous:
![prev](https://cloud.githubusercontent.com/assets/8587189/24748865/ce2108e2-1ae0-11e7-94e7-91dc0bd08a86.png)

Current:
![curr](https://cloud.githubusercontent.com/assets/8587189/24748868/d0057b5c-1ae0-11e7-8b97-c3550ad19cf5.png)
